### PR TITLE
Use managed disks as default storage class

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -393,6 +393,9 @@ write_files:
       labels:
         kubernetes.io/cluster-service: "true"
     provisioner: kubernetes.io/azure-disk
+    parameters:
+      kind: Managed
+      storageaccounttype: Premium_LRS
     ---
     apiVersion: storage.k8s.io/v1beta1
     kind: StorageClass


### PR DESCRIPTION
Switch default storage class to managed disks.

By default Azure creates blob and tries to attach it to instance, this works only for VMs with unmanaged disks (Old-style), we use managed disks VMs.