### PR TITLE
Avoid using version param in container linux module

### DIFF
--- a/modules/container-linux/main.tf
+++ b/modules/container-linux/main.tf
@@ -1,3 +1,3 @@
-data "external" "version" {
-  program = ["sh", "-c", "curl https://${var.channel}.release.core-os.net/amd64-usr/current/version.txt | sed -n 's/COREOS_VERSION=\\(.*\\)$/{\"version\": \"\\1\"}/p'"]
+data "external" "coreos_version" {
+  program = ["sh", "-c", "curl https://${var.coreos_channel}.release.core-os.net/amd64-usr/current/version.txt | sed -n 's/COREOS_VERSION=\\(.*\\)$/{\"coreos_version\": \"\\1\"}/p'"]
 }

--- a/modules/container-linux/outputs.tf
+++ b/modules/container-linux/outputs.tf
@@ -1,3 +1,3 @@
-output "version" {
-  value = "${var.version == "latest" ? data.external.version.result["version"] : var.version}"
+output "coreos_version" {
+  value = "${var.coreos_version == "latest" ? data.external.coreos_version.result["coreos_version"] : var.coreos_version}"
 }

--- a/modules/container-linux/variables.tf
+++ b/modules/container-linux/variables.tf
@@ -1,4 +1,4 @@
-variable "channel" {
+variable "coreos_channel" {
   type = "string"
 
   description = <<EOF
@@ -8,7 +8,7 @@ Examples: `stable`, `beta`, `alpha`
 EOF
 }
 
-variable "version" {
+variable "coreos_version" {
   type = "string"
 
   description = <<EOF

--- a/platforms/azure/giantnetes/main.tf
+++ b/platforms/azure/giantnetes/main.tf
@@ -1,8 +1,8 @@
 module "container_linux" {
   source = "../../../modules/container-linux"
 
-  channel = "${var.container_linux_channel}"
-  version = "${var.container_linux_version}"
+  coreos_channel = "${var.container_linux_channel}"
+  coreos_version = "${var.container_linux_version}"
 }
 
 module "resource_group" {
@@ -53,7 +53,7 @@ module "bastion" {
   cluster_name            = "${var.cluster_name}"
   core_ssh_key            = "${var.core_ssh_key}"
   container_linux_channel = "${var.container_linux_channel}"
-  container_linux_version = "${module.container_linux.version}"
+  container_linux_version = "${module.container_linux.coreos_version}"
   location                = "${var.azure_location}"
   network_interface_ids   = "${module.vnet.bastion_network_interface_ids}"
   resource_group_name     = "${module.resource_group.name}"
@@ -75,7 +75,7 @@ module "vault" {
   cloud_config_data       = "${data.template_file.vault_cloud_config.rendered}"
   cluster_name            = "${var.cluster_name}"
   container_linux_channel = "${var.container_linux_channel}"
-  container_linux_version = "${module.container_linux.version}"
+  container_linux_version = "${module.container_linux.coreos_version}"
   core_ssh_key            = "${var.core_ssh_key}"
   location                = "${var.azure_location}"
   network_interface_ids   = "${module.vnet.vault_network_interface_ids}"
@@ -91,7 +91,7 @@ module "master" {
   cloud_config_data           = "${file("${path.cwd}/generated/master.sh")}"
   cluster_name                = "${var.cluster_name}"
   container_linux_channel     = "${var.container_linux_channel}"
-  container_linux_version     = "${module.container_linux.version}"
+  container_linux_version     = "${module.container_linux.coreos_version}"
   core_ssh_key                = "${var.core_ssh_key}"
   docker_disk_size            = "100"
   etcd_disk_size              = "10"
@@ -113,7 +113,7 @@ module "worker" {
   cloud_config_data               = "${file("${path.cwd}/generated/worker.sh")}"
   cluster_name                    = "${var.cluster_name}"
   container_linux_channel         = "${var.container_linux_channel}"
-  container_linux_version         = "${module.container_linux.version}"
+  container_linux_version         = "${module.container_linux.coreos_version}"
   core_ssh_key                    = "${var.core_ssh_key}"
   docker_disk_size                = "100"
   location                        = "${var.azure_location}"


### PR DESCRIPTION
Terraform 0.11.1 reserves "version" parameter.

This change renames version to coreos_version.