### PR TITLE
Increase audit log size

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -1767,9 +1767,10 @@ coreos:
       --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem \
       --client-ca-file=/etc/kubernetes/ssl/apiserver-ca.pem \
       --service-account-key-file=/etc/kubernetes/ssl/service-account-key.pem \
+      --feature-gates=AdvancedAuditing=false \
       --audit-log-path=/var/log/apiserver/audit.log \
       --audit-log-maxage=30 \
-      --audit-log-maxbackup=10 \
+      --audit-log-maxbackup=30 \
       --audit-log-maxsize=100
       ExecStop=-/usr/bin/docker stop -t 10 $NAME
       ExecStopPost=-/usr/bin/docker rm -f $NAME


### PR DESCRIPTION
https://github.com/giantswarm/giantswarm/issues/2347

- store 30 rotated files instead of 10 (estimates size ~3G)
- add flag necessary to continue using legacy audit log in 1.8 [1]

1 - https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#legacy-audit