### PR TITLE
Fix etcd defragmentation service. Use 127.0.0.1 for etcd

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -1558,7 +1558,7 @@ coreos:
         --name $NAME \
         $IMAGE \
         etcdctl \
-        --endpoints https://${ETCD_DOMAIN_NAME}:2379 \
+        --endpoints https://127.0.0.1:2379 \
         --cacert /etc/etcd/server-ca.pem \
         --cert /etc/etcd/server-crt.pem \
         --key /etc/etcd/server-key.pem \


### PR DESCRIPTION
In azure we can not use load balancer if it points to the same node.