### PR TITLE
Calico fix RBAC rules

### DIFF
--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -965,10 +965,66 @@ write_files:
     rules:
       - apiGroups: [""]
         resources:
+          - namespaces
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups: [""]
+        resources:
+          - pods/status
+        verbs:
+          - update
+      - apiGroups: [""]
+        resources:
           - pods
+        verbs:
+          - get
+          - list
+          - watch
+          - patch
+      - apiGroups: [""]
+        resources:
+          - services
+        verbs:
+          - get
+      - apiGroups: [""]
+        resources:
+          - endpoints
+        verbs:
+          - get
+      - apiGroups: [""]
+        resources:
           - nodes
         verbs:
           - get
+          - list
+          - update
+          - watch
+      - apiGroups: ["extensions"]
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups: ["crd.projectcalico.org"]
+        resources:
+          - globalfelixconfigs
+          - felixconfigurations
+          - bgppeers
+          - globalbgpconfigs
+          - bgpconfigurations
+          - ippools
+          - globalnetworkpolicies
+          - networkpolicies
+          - clusterinformations
+        verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
     ---
     ## IC
     apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -960,23 +960,6 @@ write_files:
     kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1beta1
     metadata:
-      name: calico-policy-controller
-      namespace: kube-system
-    rules:
-      - apiGroups:
-        - ""
-        - extensions
-        resources:
-          - pods
-          - namespaces
-          - networkpolicies
-        verbs:
-          - watch
-          - list
-    ---
-    kind: ClusterRole
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
       name: calico-node
       namespace: kube-system
     rules:
@@ -1184,19 +1167,6 @@ write_files:
       apiGroup: rbac.authorization.k8s.io
     ---
     ## Calico
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: calico-policy-controller
-    subjects:
-    - kind: ServiceAccount
-      name: calico-policy-controller
-      namespace: kube-system
-    roleRef:
-      kind: ClusterRole
-      name: calico-policy-controller
-      apiGroup: rbac.authorization.k8s.io
-    ---
     kind: ClusterRoleBinding
     apiVersion: rbac.authorization.k8s.io/v1beta1
     metadata:

--- a/cloud-config/master.yaml.tmpl
+++ b/cloud-config/master.yaml.tmpl
@@ -1397,9 +1397,6 @@ write_files:
       name: calico-node
       namespace: kube-system
     - kind: ServiceAccount
-      name: calico-policy-controller
-      namespace: kube-system
-    - kind: ServiceAccount
       name: coredns
       namespace: kube-system
     - kind: ServiceAccount


### PR DESCRIPTION
As we are using calico with kubernetes datastore, `calico-node` cluster role requires different rules from those we are using with etcd backed calico. Rules are taken from upstream: https://github.com/projectcalico/calico/blob/master/v3.0/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
Also this PR removes calico policy-controller related RBAC stuff